### PR TITLE
사용자끼리의 팔로우, 자신의 팔로우 정보 조회 기능 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,10 @@ dependencies {
     // test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:5.6.1")
+    testImplementation("io.mockk:mockk:1.13.5")
+    testImplementation("com.ninja-squad:springmockk:4.0.2")
+    testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.2")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/com/tianea/fimo/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/tianea/fimo/config/SecurityConfig.kt
@@ -28,7 +28,7 @@ class SecurityConfig(
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
             .authorizeHttpRequests()
             .requestMatchers("/login/**").permitAll()
-            .requestMatchers("/test/user").hasRole("USER")
+            .requestMatchers("/test/**").permitAll()
             .requestMatchers("/api/v1/**").hasRole("USER")
             .anyRequest().denyAll()
             .and()

--- a/src/main/kotlin/com/tianea/fimo/domain/feed/service/FeedService.kt
+++ b/src/main/kotlin/com/tianea/fimo/domain/feed/service/FeedService.kt
@@ -1,0 +1,34 @@
+package com.tianea.fimo.domain.feed.service
+
+import com.tianea.fimo.domain.follow.repository.FollowRepository
+import com.tianea.fimo.domain.post.dto.PostReadDTO
+import com.tianea.fimo.domain.post.repository.PostClickRepository
+import com.tianea.fimo.domain.post.repository.PostItemRepository
+import com.tianea.fimo.domain.post.repository.PostRepository
+import com.tianea.fimo.domain.user.error.UserNotFoundException
+import com.tianea.fimo.domain.user.repository.UserRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class FeedService(
+    private val followRepository: FollowRepository,
+    private val postRepository: PostRepository,
+    private val userRepository: UserRepository,
+    private val postClickRepository: PostClickRepository,
+    private val postItemRepository: PostItemRepository,
+) {
+    @Transactional(readOnly = true)
+    fun getFeed(loginId: String): List<PostReadDTO> {
+        val follows = followRepository.findAllByFollower(loginId)
+        val ids = follows.map { follow -> follow.followee } + listOf(loginId)
+        return postRepository.findAllByUserIdInOrderByCreatedAtDesc(ids)
+            .map { post ->
+                val user = userRepository.findByIdOrNull(post.userId) ?: throw UserNotFoundException()
+                val isClicked = postClickRepository.existsByPostIdAndUserId(post.id, loginId)
+                val items = postItemRepository.findAllByPostId(post.id)
+                PostReadDTO.from(user = user, post = post, items = items, isClicked = isClicked)
+            }
+    }
+}

--- a/src/main/kotlin/com/tianea/fimo/domain/follow/dto/FollowReadDTO.kt
+++ b/src/main/kotlin/com/tianea/fimo/domain/follow/dto/FollowReadDTO.kt
@@ -1,0 +1,26 @@
+package com.tianea.fimo.domain.follow.dto
+
+import com.tianea.fimo.domain.user.dto.UserReadDTO
+import com.tianea.fimo.domain.user.entity.User
+
+class FollowReadDTO(
+    val user: UserReadDTO,
+    val postCount: Int,
+    val status: FollowStatus
+) {
+    companion object {
+        fun from(user: User, status: FollowStatus, postCount: Int): FollowReadDTO {
+            return FollowReadDTO(
+                user = UserReadDTO.from(user),
+                postCount = postCount,
+                status = status
+            )
+        }
+    }
+
+    override fun toString(): String = "FollowReadDTO(user=$user, postCount=$postCount, status=$status)"
+}
+
+enum class FollowStatus {
+    FOLLOWING, FOLLOWED, MUTUAL
+}

--- a/src/main/kotlin/com/tianea/fimo/domain/follow/entity/Follow.kt
+++ b/src/main/kotlin/com/tianea/fimo/domain/follow/entity/Follow.kt
@@ -1,0 +1,32 @@
+package com.tianea.fimo.domain.follow.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "follows")
+class Follow(
+    @Id
+    val id: String,
+    val follower: String,
+    val followee: String,
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime = LocalDateTime.now()
+) {
+    override fun equals(other: Any?): Boolean {
+        if (other !is Follow) return false
+        val f = other as Follow
+        return (this.follower == f.follower && this.followee == f.followee) || (this.follower == f.followee && this.followee == f.follower)
+    }
+
+    override fun toString(): String =
+        "Follow(id='$id', follower='$follower', followee='$followee', createdAt=$createdAt)"
+
+    override fun hashCode(): Int = if (follower > followee)
+        follower.hashCode() + followee.hashCode()
+    else
+        followee.hashCode() + follower.hashCode()
+}

--- a/src/main/kotlin/com/tianea/fimo/domain/follow/repository/FollowRepository.kt
+++ b/src/main/kotlin/com/tianea/fimo/domain/follow/repository/FollowRepository.kt
@@ -1,0 +1,13 @@
+package com.tianea.fimo.domain.follow.repository
+
+import com.tianea.fimo.domain.follow.entity.Follow
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface FollowRepository : JpaRepository<Follow, String>{
+    fun existsByFollowerAndFollowee(follower :String, followee:String): Boolean
+    fun deleteByFollowerAndFollowee(follower: String, followee: String)
+    fun findAllByFollowee(followee: String) : List<Follow>
+    fun findAllByFollower(follower:String) : List<Follow>
+}

--- a/src/main/kotlin/com/tianea/fimo/domain/follow/service/FollowService.kt
+++ b/src/main/kotlin/com/tianea/fimo/domain/follow/service/FollowService.kt
@@ -1,0 +1,58 @@
+package com.tianea.fimo.domain.follow.service
+
+import com.tianea.fimo.domain.follow.dto.FollowReadDTO
+import com.tianea.fimo.domain.follow.dto.FollowStatus
+import com.tianea.fimo.domain.follow.entity.Follow
+import com.tianea.fimo.domain.follow.repository.FollowRepository
+import com.tianea.fimo.domain.post.repository.PostRepository
+import com.tianea.fimo.domain.user.error.UserNotFoundException
+import com.tianea.fimo.domain.user.repository.UserRepository
+import com.tianea.fimo.shared.provider.IdentifierProvider
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class FollowService(
+    private val followRepository: FollowRepository,
+    private val userRepository: UserRepository,
+    private val postRepository: PostRepository,
+    private val provider: IdentifierProvider
+) {
+
+    @Transactional(readOnly = true)
+    fun myFollowers(loginId: String): List<FollowReadDTO> {
+        val follower = followRepository.findAllByFollower(loginId).toSet()
+        val followee = followRepository.findAllByFollowee(loginId).toSet()
+
+        val onlyMe = (follower - followee).map { follow ->
+            val user = userRepository.findByIdOrNull(follow.followee) ?: throw UserNotFoundException()
+            val postCount = postRepository.countByUserId(user.id)
+            FollowReadDTO.from(user = user, status = FollowStatus.FOLLOWING, postCount = postCount)
+        }
+        val onlyYou = (followee - follower).map { follow ->
+            val user = userRepository.findByIdOrNull(follow.follower) ?: throw UserNotFoundException()
+            val postCount = postRepository.countByUserId(user.id)
+            FollowReadDTO.from(user = user, status = FollowStatus.FOLLOWED, postCount = postCount)
+        }
+        val both = follower.intersect(followee).map { follow ->
+            val user = userRepository.findByIdOrNull(follow.followee) ?: throw UserNotFoundException()
+            val postCount = postRepository.countByUserId(user.id)
+            FollowReadDTO.from(user = user, status = FollowStatus.MUTUAL, postCount = postCount)
+        }
+        return onlyMe + onlyYou + both
+    }
+
+    @Transactional
+    fun follow(loginId: String, followee: String) {
+        if (followRepository.existsByFollowerAndFollowee(loginId, followee)) return
+        if(!userRepository.existsById(followee)) return
+        val follow = Follow(provider.generateId(), loginId, followee)
+        followRepository.save(follow)
+    }
+
+    @Transactional
+    fun unfollow(loginId: String, followee: String) {
+        followRepository.deleteByFollowerAndFollowee(loginId, followee)
+    }
+}

--- a/src/main/kotlin/com/tianea/fimo/domain/post/dto/PostCreateDTO.kt
+++ b/src/main/kotlin/com/tianea/fimo/domain/post/dto/PostCreateDTO.kt
@@ -2,8 +2,7 @@ package com.tianea.fimo.domain.post.dto
 
 import com.tianea.fimo.domain.post.entity.Post
 import com.tianea.fimo.domain.post.entity.PostItem
-import com.tianea.fimo.domain.post.service.PostIdentifierProvider
-import java.time.LocalDateTime
+import com.tianea.fimo.shared.provider.IdentifierProvider
 
 
 class PostCreateDTO(
@@ -13,7 +12,7 @@ class PostCreateDTO(
         return Post(id = id, userId = userId)
     }
 
-    fun createItems(postId: String, provider: PostIdentifierProvider): List<PostItem> =
+    fun createItems(postId: String, provider: IdentifierProvider): List<PostItem> =
         items.map { item -> item.toEntity(provider.generateId(), postId) }
 }
 

--- a/src/main/kotlin/com/tianea/fimo/domain/post/dto/PostUpdateDTO.kt
+++ b/src/main/kotlin/com/tianea/fimo/domain/post/dto/PostUpdateDTO.kt
@@ -1,12 +1,12 @@
 package com.tianea.fimo.domain.post.dto
 
 import com.tianea.fimo.domain.post.entity.PostItem
-import com.tianea.fimo.domain.post.service.PostIdentifierProvider
+import com.tianea.fimo.shared.provider.IdentifierProvider
 
 class PostUpdateDTO(
     val items: List<PostItemUpdateDTO>
 ) {
-    fun createPostItems(postId: String, provider: PostIdentifierProvider): List<PostItem> =
+    fun createPostItems(postId: String, provider: IdentifierProvider): List<PostItem> =
         items.map { item ->
             PostItem(
                 id = provider.generateId(),

--- a/src/main/kotlin/com/tianea/fimo/domain/post/repository/PostRepository.kt
+++ b/src/main/kotlin/com/tianea/fimo/domain/post/repository/PostRepository.kt
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Repository
 interface PostRepository : JpaRepository<Post, String>{
     @Query("SELECT p FROM Post p ORDER BY p.createdAt DESC")
     fun findAllSortedByCreatedAtDesc(): List<Post>
+    fun countByUserId(userId: String): Int
 }
 
 

--- a/src/main/kotlin/com/tianea/fimo/domain/post/repository/PostRepository.kt
+++ b/src/main/kotlin/com/tianea/fimo/domain/post/repository/PostRepository.kt
@@ -8,10 +8,12 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
 @Repository
-interface PostRepository : JpaRepository<Post, String>{
+interface PostRepository : JpaRepository<Post, String> {
     @Query("SELECT p FROM Post p ORDER BY p.createdAt DESC")
     fun findAllSortedByCreatedAtDesc(): List<Post>
     fun countByUserId(userId: String): Int
+    fun findAllByUserId(userId: String): List<Post>
+    fun findAllByUserIdInOrderByCreatedAtDesc(ids: List<String>): List<Post>
 }
 
 

--- a/src/main/kotlin/com/tianea/fimo/domain/post/service/PostService.kt
+++ b/src/main/kotlin/com/tianea/fimo/domain/post/service/PostService.kt
@@ -66,12 +66,22 @@ class PostService(
     }
 
     @Transactional(readOnly = true)
-    fun findById(loginId : String, postId :String): PostReadDTO {
+    fun findById(loginId: String, postId: String): PostReadDTO {
         val post = postRepository.findByIdOrNull(postId) ?: throw PostNotFoundException()
         val user = userRepository.findByIdOrNull(post.userId) ?: throw UserNotFoundException()
         val items = postItemRepository.findAllByPostId(post.id)
         val isClicked = postClickRepository.existsByPostIdAndUserId(userId = loginId, postId = post.id)
         return PostReadDTO.from(user, post, items, isClicked)
     }
+
+
+    @Transactional(readOnly = true)
+    fun findAllByUserId(loginId: String, userId: String): List<PostReadDTO> =
+        postRepository.findAllByUserId(userId).map { post ->
+            val items = postItemRepository.findAllByPostId(post.id)
+            val user = userRepository.findByIdOrNull(post.userId) ?: throw UserNotFoundException()
+            val isClicked = postClickRepository.existsByPostIdAndUserId(userId = loginId, postId = post.id)
+            PostReadDTO.from(user, post, items, isClicked)
+        }
 }
 

--- a/src/main/kotlin/com/tianea/fimo/domain/post/service/PostService.kt
+++ b/src/main/kotlin/com/tianea/fimo/domain/post/service/PostService.kt
@@ -10,10 +10,10 @@ import com.tianea.fimo.domain.post.repository.PostItemRepository
 import com.tianea.fimo.domain.post.repository.PostRepository
 import com.tianea.fimo.domain.user.error.UserNotFoundException
 import com.tianea.fimo.domain.user.repository.UserRepository
+import com.tianea.fimo.shared.provider.IdentifierProvider
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.util.UUID
 
 @Service
 class PostService(
@@ -21,7 +21,7 @@ class PostService(
     private val postRepository: PostRepository,
     private val postItemRepository: PostItemRepository,
     private val postClickRepository: PostClickRepository,
-    private val provider: PostIdentifierProvider
+    private val provider: IdentifierProvider
 ) {
     @Transactional
     fun createPost(loginId: String, create: PostCreateDTO): PostReadDTO {
@@ -75,7 +75,3 @@ class PostService(
     }
 }
 
-@Service
-class PostIdentifierProvider() {
-    fun generateId(): String = UUID.randomUUID().toString()
-}

--- a/src/main/kotlin/com/tianea/fimo/domain/user/dto/UserReadDTO.kt
+++ b/src/main/kotlin/com/tianea/fimo/domain/user/dto/UserReadDTO.kt
@@ -15,4 +15,6 @@ class UserReadDTO(
             archiveName = user.archiveName
         )
     }
+
+    override fun toString(): String = "UserReadDTO(id='$id', nickname='$nickname', archiveName='$archiveName')"
 }

--- a/src/main/kotlin/com/tianea/fimo/shared/provider/IdentifierProvider.kt
+++ b/src/main/kotlin/com/tianea/fimo/shared/provider/IdentifierProvider.kt
@@ -1,0 +1,10 @@
+package com.tianea.fimo.shared.provider
+
+import org.springframework.stereotype.Service
+import java.util.*
+
+
+@Service
+class IdentifierProvider() {
+    fun generateId(): String = UUID.randomUUID().toString()
+}

--- a/src/main/kotlin/com/tianea/fimo/web/TestController.kt
+++ b/src/main/kotlin/com/tianea/fimo/web/TestController.kt
@@ -1,13 +1,30 @@
 package com.tianea.fimo.web
 
+import com.tianea.fimo.domain.user.entity.User
+import com.tianea.fimo.domain.user.repository.UserRepository
+import com.tianea.fimo.shared.security.JwtService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 
 @RequestMapping("/test")
 @RestController
-class TestController {
+class TestController(
+    private val jwtService: JwtService,
+    private val userRepository: UserRepository,
+
+    ) {
     @GetMapping("/user")
     fun user(): String = "user"
+
+    @GetMapping("/login")
+    fun login(@RequestParam("userId") userId: String): String {
+        if (!userRepository.existsById(userId)) {
+            val user = User(id = userId, nickname = "test", archiveName = "test")
+            userRepository.save(user)
+        }
+        return jwtService.createAccessToken(userId)
+    }
 }

--- a/src/main/kotlin/com/tianea/fimo/web/feed/FeedController.kt
+++ b/src/main/kotlin/com/tianea/fimo/web/feed/FeedController.kt
@@ -1,0 +1,17 @@
+package com.tianea.fimo.web.feed
+
+import com.tianea.fimo.domain.feed.service.FeedService
+import com.tianea.fimo.domain.post.dto.PostReadDTO
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.security.Principal
+
+@RestController
+@RequestMapping("/api/v1/feed")
+class FeedController(
+    private val feedService: FeedService
+) {
+    @GetMapping("")
+    fun feed(principal: Principal): List<PostReadDTO> = feedService.getFeed(principal.name)
+}

--- a/src/main/kotlin/com/tianea/fimo/web/follow/FollowController.kt
+++ b/src/main/kotlin/com/tianea/fimo/web/follow/FollowController.kt
@@ -1,0 +1,31 @@
+package com.tianea.fimo.web.follow
+
+import com.tianea.fimo.domain.follow.dto.FollowReadDTO
+import com.tianea.fimo.domain.follow.service.FollowService
+import com.tianea.fimo.web.post.CommonResponse
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.security.Principal
+
+@RestController
+@RequestMapping("/api/v1/follow")
+class FollowController(
+    private val followService: FollowService
+) {
+    @GetMapping("/me")
+    fun getMyFollows(principal: Principal): List<FollowReadDTO> = followService.myFollowers(principal.name)
+
+    @PostMapping("/following/{followee}")
+    fun follow(principal: Principal, @PathVariable("followee") followee: String): CommonResponse {
+        followService.follow(principal.name, followee)
+        return CommonResponse(code = "follow success", message = "follow success", status = 200)
+    }
+    @PostMapping("/unfollowing/{followee}")
+    fun unfollow(principal: Principal, @PathVariable("followee") followee: String): CommonResponse {
+        followService.unfollow(principal.name, followee)
+        return CommonResponse(code = "unfollow success", message = "unfollow success", status = 200)
+    }
+}

--- a/src/main/kotlin/com/tianea/fimo/web/post/PostController.kt
+++ b/src/main/kotlin/com/tianea/fimo/web/post/PostController.kt
@@ -36,9 +36,14 @@ class PostController(
 
     @GetMapping("")
     fun findAll(principal: Principal): List<PostReadDTO> = postService.findAll(principal.name)
+
     @GetMapping("/details/{postId}")
     fun findById(@PathVariable("postId") postId: String, principal: Principal): PostReadDTO =
         postService.findById(loginId = principal.name, postId = postId)
+
+    @GetMapping("/user/{userId}")
+    fun findByUserId(@PathVariable("userId") userId: String, principal: Principal): List<PostReadDTO> =
+        postService.findAllByUserId(loginId = principal.name, userId = userId)
 
 }
 

--- a/src/test/kotlin/com/tianea/fimo/domain/follow/service/FollowServiceTest.kt
+++ b/src/test/kotlin/com/tianea/fimo/domain/follow/service/FollowServiceTest.kt
@@ -1,0 +1,86 @@
+package com.tianea.fimo.domain.follow.service
+
+import com.ninjasquad.springmockk.MockkBean
+import com.tianea.fimo.domain.follow.dto.FollowStatus
+import com.tianea.fimo.domain.follow.entity.Follow
+import com.tianea.fimo.domain.follow.repository.FollowRepository
+import com.tianea.fimo.domain.post.repository.PostRepository
+import com.tianea.fimo.domain.user.entity.User
+import com.tianea.fimo.domain.user.repository.UserRepository
+import com.tianea.fimo.shared.provider.IdentifierProvider
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.junit5.MockKExtension
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.repository.findByIdOrNull
+
+@SpringBootTest
+@ExtendWith(MockKExtension::class)
+class FollowServiceTest(
+    @InjectMockKs
+    private val followService: FollowService,
+    @MockkBean
+    private val followRepository: FollowRepository,
+    @MockkBean
+    private val userRepository: UserRepository,
+    @MockkBean
+    private val postRepository: PostRepository,
+    @MockkBean
+    private val provider: IdentifierProvider
+) : BehaviorSpec({
+
+    given("사용자가 3명 있을 때 ") {
+        val userA = "userA"
+        val userB = "userB"
+        val userC = "userC"
+        val userD = "userD"
+
+        every { userRepository.findByIdOrNull(userA) } returns User(
+            id = userA,
+            nickname = "user_a",
+            archiveName = "user_archive_a",
+        )
+        every { userRepository.findByIdOrNull(userB) } returns User(
+            id = userB,
+            nickname = "user_b",
+            archiveName = "user_archive_b",
+        )
+        every { userRepository.findByIdOrNull(userC) } returns User(
+            id = userC,
+            nickname = "user_c",
+            archiveName = "user_archive_c",
+        )
+        every { userRepository.findByIdOrNull(userD) } returns User(
+            id = userD,
+            nickname = "user_d",
+            archiveName = "user_archive_d",
+        )
+
+        every { postRepository.countByUserId(any()) } returns 0
+
+        `when`("어느 한 사용자가 팔로우 목록을 조회하면") {
+            every { followRepository.findAllByFollower(userA) } returns listOf(
+                Follow("1", userA, userB),
+                Follow("2", userA, userC),
+            )
+
+            every { followRepository.findAllByFollowee(userA) } returns listOf(
+                Follow("3", userB, userA),
+                Follow("4", userD, userA)
+            )
+
+            val reads = followService.myFollowers(userA)
+
+            then("나만 팔로우, 너만 팔로우, 모두 팔로우가 FollowReadDTO로 반환된다.") {
+                reads.size shouldBe 3
+                reads.count { it.status == FollowStatus.FOLLOWING } shouldBe 1
+                reads.count { it.status == FollowStatus.FOLLOWED } shouldBe 1
+                reads.count { it.status == FollowStatus.MUTUAL } shouldBe 1
+            }
+        }
+    }
+})


### PR DESCRIPTION
팔로우, 언팔로우, 자신의 팔로우 현황 조회의 기능을 구현했습니다.
팔로우 현황에는 (오직 나만, 오직 너만, 맞팔)의 상태를 같이 보내줌으로써 실제 인스타나, 깃헙 팔로우처럼 동작하도록 구현했습니다. 