### PR TITLE
fix :서버 도메인이 https가 아니라 http로 보내지는 문제 해결

### DIFF
--- a/src/main/kotlin/com/tianea/fimo/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/tianea/fimo/config/SwaggerConfig.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
+import io.swagger.v3.oas.models.servers.Server
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -30,8 +31,15 @@ class SwaggerConfig {
                     .bearerFormat("JWT")
             )
 
+        val deploy = Server()
+        deploy.url = "https://fimo.k-net.kr"
+
+        val test = Server()
+        test.url = "http://localhost:8080"
+
         return OpenAPI()
             .info(info)
+            .servers(listOf(deploy, test))
             .addSecurityItem(securityRequirement)
             .components(components)
     }


### PR DESCRIPTION
###  변경 해야할 사항

![로그인 오류 화면](https://github.com/Tianea2160/fimo/assets/73744183/840d9bed-f2fe-454d-af4a-56f6c2f47fd5)

https로 요청이 보내져야하는 것이 http로 요청이 보내져서 문제가 발생했습니다.

### 문제해결

![스웨거 문제 해결 화면](https://github.com/Tianea2160/fimo/assets/73744183/7ddddc50-9750-4dc2-9b22-c8119a08125a)

https로 스웨거 세팅을 변경하여 문제가 없도록 수정했습니다.
