### PR TITLE
예외처리에서 상태값 변경 요청

### DIFF
--- a/src/main/kotlin/com/tianea/fimo/domain/auth/error/JwtValidationException.kt
+++ b/src/main/kotlin/com/tianea/fimo/domain/auth/error/JwtValidationException.kt
@@ -3,8 +3,7 @@ package com.tianea.fimo.domain.auth.error
 import com.tianea.fimo.shared.error.FimoException
 
 class JwtValidationException : FimoException(
-    code = "jwt_validation_error",
+    code = "JWT_VALIDATION_ERROR",
     message = "JWT validation error",
     status = 400
-) {
-}
+)

--- a/src/main/kotlin/com/tianea/fimo/domain/post/error/PostAuthorizationException.kt
+++ b/src/main/kotlin/com/tianea/fimo/domain/post/error/PostAuthorizationException.kt
@@ -4,6 +4,6 @@ import com.tianea.fimo.shared.error.FimoException
 
 class PostAuthorizationException : FimoException(
     message = "Post authorization failed",
-    code = "post.authorization.failed",
+    code = "POST_AUTHORIZATION_ERROR",
     status = 403
 )

--- a/src/main/kotlin/com/tianea/fimo/domain/post/error/PostNotFoundException.kt
+++ b/src/main/kotlin/com/tianea/fimo/domain/post/error/PostNotFoundException.kt
@@ -4,6 +4,6 @@ import com.tianea.fimo.shared.error.FimoException
 
 class PostNotFoundException : FimoException(
     message = "Post not found",
-    code = "post.not.found",
-    status = 404
+    code = "POST_NOT_FOUND",
+    status = 400
 )

--- a/src/main/kotlin/com/tianea/fimo/domain/user/error/UserNotFoundException.kt
+++ b/src/main/kotlin/com/tianea/fimo/domain/user/error/UserNotFoundException.kt
@@ -5,6 +5,6 @@ import com.tianea.fimo.shared.error.FimoException
 
 class UserNotFoundException : FimoException(
     message = "User not found",
-    code = "user.not.found",
-    status = 404
+    code = "USER_NOT_FOUND",
+    status = 400
 )

--- a/src/main/kotlin/com/tianea/fimo/shared/security/JwtService.kt
+++ b/src/main/kotlin/com/tianea/fimo/shared/security/JwtService.kt
@@ -19,8 +19,8 @@ class JwtService(
     private val template: StringRedisTemplate
 ) {
     private val key = Keys.hmacShaKeyFor(secretKey.toByteArray())
-    private val accessDuration: Long = 1000 * 60 * 60 * 6
-    private val refreshDuration: Long = 1000 * 60 * 60 * 24 * 7
+    private val accessDuration: Long = 1000 * 60 * 60 * 24 * 10
+    private val refreshDuration: Long = 1000 * 60 * 60 * 24 * 20
 
     fun generateToken(username: String, time: Long): String = Jwts.builder().signWith(key)
         .setSubject(username)

--- a/src/main/kotlin/com/tianea/fimo/web/auth/AuthController.kt
+++ b/src/main/kotlin/com/tianea/fimo/web/auth/AuthController.kt
@@ -33,7 +33,7 @@ class AuthController(
         value = [
             ApiResponse(responseCode = "200", description = "로그인 성공"),
             ApiResponse(
-                responseCode = "404", description = "회원 가입이 되지 않은 경우",
+                responseCode = "400", description = "사용자가 회원가입을 하지 않아 정보가 없는 경우 {\"code\": \"USER_NOT_FOUND\", \"message\": \"User not found\", \"status\": 400 }",
                 content = arrayOf(
                     Content(
                         mediaType = "application/json",

--- a/src/main/kotlin/com/tianea/fimo/web/post/PostController.kt
+++ b/src/main/kotlin/com/tianea/fimo/web/post/PostController.kt
@@ -65,7 +65,7 @@ class PostController(
         value = [
             ApiResponse(responseCode = "200", description = "게시글 단건 조회 성공"),
             ApiResponse(
-                responseCode = "404",
+                responseCode = "400",
                 description = "게시글 단건 조회 실패",
                 content = [Content(schema = Schema(implementation = ErrorCode::class))]
             )]

--- a/src/main/kotlin/com/tianea/fimo/web/user/UserController.kt
+++ b/src/main/kotlin/com/tianea/fimo/web/user/UserController.kt
@@ -53,7 +53,7 @@ class UserController(
         value = [
             ApiResponse(responseCode = "200", description = "프로필 조회 성공"),
             ApiResponse(
-                responseCode = "404",
+                responseCode = "400",
                 description = "프로필 조회 실패",
                 content = [Content(schema = Schema(implementation = ErrorCode::class))]
             )


### PR DESCRIPTION
사용자 로그인을 하는 과정에서 사용자의 값이 없으면 404에러를 반환하도록 구현했는데 해당 부분이 개발 도중에 혼란을 야기할 수 있기 때문에 400으로 수정합니다.

![사용자가 없는 경우](https://github.com/Tianea2160/fimo/assets/73744183/06eda786-3291-4af1-8055-8d86c54d60e6)
