### PR TITLE
fix : change nickname, archive name validation check api role

### DIFF
--- a/src/main/kotlin/com/tianea/fimo/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/tianea/fimo/config/SecurityConfig.kt
@@ -27,7 +27,7 @@ class SecurityConfig(
             .authorizeHttpRequests()
             .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
             .requestMatchers("/api/v1/auth/logout").authenticated()
-            .requestMatchers("/api/v1/auth/**").permitAll()
+            .requestMatchers("/api/v1/auth/**", "/api/v1/user/validate/**").permitAll()
             .requestMatchers("/test/**").permitAll()
             .requestMatchers("/api/v1/auth/**").permitAll()
             .requestMatchers("/api/v1/**").hasRole("USER")


### PR DESCRIPTION
닉네임과 아카이브 이름 중복 체크 로직이 권한없이 정상적으로 작동하는 것을 확인했습니다.