### PR TITLE
fix : add profile image url field in user read dto

### DIFF
--- a/src/main/kotlin/com/tianea/fimo/domain/user/dto/UserReadDTO.kt
+++ b/src/main/kotlin/com/tianea/fimo/domain/user/dto/UserReadDTO.kt
@@ -6,13 +6,15 @@ import com.tianea.fimo.domain.user.entity.User
 class UserReadDTO(
     val id: String,
     val nickname: String,
-    val archiveName: String
+    val archiveName: String,
+    val profileImageUrl : String,
 ) {
     companion object {
         fun from(user: User) = UserReadDTO(
             id = user.id,
             nickname = user.nickname,
-            archiveName = user.archiveName
+            archiveName = user.archiveName,
+            profileImageUrl = user.profileImageUrl
         )
     }
 


### PR DESCRIPTION
프로필 이미지 필드가 누락된 부분 해결
archiveName 대신에 profileImageUrl이 필요하다는 요청이 들어와서 해당 부분을 수정했습니다.
다만 archiveName이 다른 곳에서 사용될 수 있어서 필드는 삭제하거나 변경하지는 않고 추가하는 형태로 문제를 해결했습니다.